### PR TITLE
inclui execuções de bundler install para instalar os pacotes da aplic…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ RUN bundle install
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
-EXPOSE 3000
+
+RUN gem install nokogiri --platform=ruby
+RUN bundle config set force_ruby_platform true
+RUN bundler install
 
 EXPOSE 3000
 


### PR DESCRIPTION
Ao tentar executar o docker compose build e executar algum comando do rails dentro do container, caímos em erro de gems não instaladas. Para resolver esse problema, a instrução bundler install foi adicionadas no dockerfile.